### PR TITLE
Improve OS-related params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 # [*package_prefix*]
 #  Prefix in the name of perl modules, when installed via OS packages
 #
+# [*package_suffix*]
+#  Suffix in the name of perl modules, when installed via OS packages
+#
+#
 # Standard class parameters
 # Define the general class behaviour and customizations
 #
@@ -50,15 +54,16 @@
 #
 #
 class perl (
-  $cpan_mirror         = params_lookup( 'cpan_mirror' ),
-  $package_prefix      = params_lookup( 'package_prefix' ),
-  $my_class            = params_lookup( 'my_class' ),
-  $version             = params_lookup( 'version' ),
-  $absent              = params_lookup( 'absent' ),
-  $noops               = params_lookup( 'noops' ),
-  $package             = params_lookup( 'package' ),
-  $doc_package         = params_lookup( 'doc_package' ),
-  $doc_version         = params_lookup( 'doc_version' )
+  $cpan_mirror          = params_lookup( 'cpan_mirror' ),
+  $package_prefix       = params_lookup( 'package_prefix' ),
+  $package_suffix       = params_lookup( 'package_suffix' ),
+  $my_class             = params_lookup( 'my_class' ),
+  $version              = params_lookup( 'version' ),
+  $absent               = params_lookup( 'absent' ),
+  $noops                = params_lookup( 'noops' ),
+  $package              = params_lookup( 'package' ),
+  $doc_package          = params_lookup( 'doc_package' ),
+  $doc_version          = params_lookup( 'doc_version' )
   ) inherits perl::params {
 
   $bool_absent=any2bool($absent)

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -16,6 +16,7 @@ define perl::module (
   $use_package         = false,
   $package_name        = '',
   $package_prefix      = $perl::package_prefix,
+  $package_suffix      = $perl::package_suffix,
 
   $url                 = '',
   $exec_path           = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin',
@@ -30,7 +31,7 @@ define perl::module (
 
   $pkg_name = regsubst($name,'::','-')
   $real_package_name = $package_name ? {
-    ''      => "${package_prefix}${pkg_name}",
+    ''      => "${package_prefix}${pkg_name}${package_suffix}",
     default => $package_name,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,17 +16,32 @@ class perl::params {
 
   ### Application related parameters
   $cpan_mirror = 'http://www.perl.com/CPAN/'
-  $package_prefix = 'perl-'
 
-  $package = $::operatingsystem ? {
-    default => 'perl',
+  ### OS specific parameters
+  case $::operatingsystem {
+    /^(Debian|Ubuntu)$/ : {
+      $package        = 'perl'
+      $doc_package    = 'perl-doc'
+      $package_prefix = 'lib'
+      $package_suffix = '-perl'
+    }
+
+    /^(RedHat|CentOS)$/ : {
+      $package        = 'perl'
+      $doc_package    = 'perl'
+      $package_prefix = 'perl-'
+      $package_suffix = ''
+    }
+
+    default : {
+      $package = 'perl'
+      $doc_package = 'perl-doc'
+      $package_prefix = 'perl-'
+      $package_suffix = ''
+    }
   }
 
-  $doc_package = $::operatingsystem ? {
-    default => 'perl-doc',
-  }
-
-  # General Settings
+  ### General Settings
   $my_class = ''
   $version = 'present'
   $doc_version = 'present'


### PR DESCRIPTION
This patch tries improve params detection based on $::operatingsystem : 
- "doc_package" is quite os-dependant, puppetdoc beeing provided by the perl package in RHEL/CentOS flavours, perl-doc in Debian & derivates
- "Automatic" package naming is also tied to the OS : RHEL/CentOS flavours are often naming packages perl-<module_name> but Debian & friends are naming them lib<module_name>-perl (thus adding the "$package_suffix" variable".

Default values have been kept.
