### PR TITLE
Added "HOME" env variable to cpan

### DIFF
--- a/manifests/cpan.pp
+++ b/manifests/cpan.pp
@@ -27,6 +27,7 @@ EOF",
     user    => root,
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',
     timeout => 600,
+    environment => [ 'HOME=/root' ],
   }
 
 }


### PR DESCRIPTION
cpan binary requires HOME variable, which under some conditions isn't provided by puppet's environment (e.g. vagrant's puppet standalone provider)
Assuming user is always root, set to `/root`

I tested more thoroughly this time :)
