### PR TITLE
Doc fix + lowercase pkg name on Debian

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -4,7 +4,7 @@
 #
 # Variables:
 # [*use_package*]
-#   (default=true) - Tries to install perl module with the relevant OS package
+#   (default=false) - Tries to install perl module with the relevant OS package
 #   If set to "no" it installs the module via a cpanm command
 #
 # Usage:
@@ -17,6 +17,7 @@ define perl::module (
   $package_name        = '',
   $package_prefix      = $perl::package_prefix,
   $package_suffix      = $perl::package_suffix,
+  $package_downcase    = $perl::package_downcase,
 
   $url                 = '',
   $exec_path           = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin',
@@ -28,7 +29,11 @@ define perl::module (
 
   require perl
 
-  $pkg_name = regsubst($name,'::','-')
+  $pkg_name = $package_downcase ? {
+    true  => downcase(regsubst($name,'::','-')),
+    false => regsubst($name,'::','-'),
+  }
+
   $real_package_name = $package_name ? {
     ''      => "${package_prefix}${pkg_name}${package_suffix}",
     default => $package_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,19 +20,21 @@ class perl::params {
   ### OS specific parameters
   case $::operatingsystem {
     /^(Debian|Ubuntu)$/ : {
-      $package        = 'perl'
-      $doc_package    = 'perl-doc'
-      $cpan_package   = 'perl'
-      $package_prefix = 'lib'
-      $package_suffix = '-perl'
+      $package          = 'perl'
+      $doc_package      = 'perl-doc'
+      $cpan_package     = 'perl'
+      $package_prefix   = 'lib'
+      $package_suffix   = '-perl'
+      $package_downcase = true
     }
 
     /^(RedHat|CentOS|Amazon)$/ : {
-      $package        = 'perl'
-      $doc_package    = ''
-      $cpan_package   = 'perl-CPAN'
-      $package_prefix = 'perl-'
-      $package_suffix = ''
+      $package          = 'perl'
+      $doc_package      = ''
+      $cpan_package     = 'perl-CPAN'
+      $package_prefix   = 'perl-'
+      $package_suffix   = ''
+      $package_downcase = false
     }
 
     default : {


### PR DESCRIPTION
Fix the documentation of perl::module to state that `use_package` is
`false` by default.

On Debian based systems, the $pkg_name is not correctly determined by
`perl::module`. If a manifest defines a `perl::module` for `Net::DNS`,
and `$use_package` is `true`, then it defines a package resource for
`libNet-DNS-perl`.  The underlying APT system is smart enough to
recognise this, but Puppet is not clever enough to see that
`libnet-dns-perl` and `libNet-DNS-perl` are basically identical. As a
result, every Puppet agent run will result in a notice for
`Package[libNet-DNS-perl]` stating "`ensure changed 'purged' to
'present'`".