### PR TITLE
Add module_check_cmd parameter to module classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The actual package installed in this case is therefore: perl-YAML-Perl
           exec_environment => [ "http_proxy=http://proxy.example42.com:8080" , "https_proxy=https://proxy.example42.com:8080" ],
         }
 
+* Specify an alternate command to check for existence of the module
+
+		perl::cpan::module { 'Bundle::LWP':
+		  module_check_cmd => "perldoc -l LWP",
+		}
 
 ## USAGE - Basic management
 

--- a/manifests/cpan/module.pp
+++ b/manifests/cpan/module.pp
@@ -17,6 +17,7 @@ define perl::cpan::module (
   $package_name        = '',
   $package_prefix      = $perl::package_prefix,
   $package_suffix      = $perl::package_suffix,
+  $module_check_cmd    = "perldoc -l ${name}",
 
   $url                 = '',
   $exec_path           = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin',
@@ -51,8 +52,8 @@ define perl::cpan::module (
   }
 
   $cpan_command_check = $ensure ? {
-    present => "perldoc -l ${name}",
-    absent  => "perldoc -l ${name} || true",
+    present => "${module_check_cmd}",
+    absent  => "${module_check_cmd} || true",
   }
 
   case $bool_use_package {

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -18,6 +18,7 @@ define perl::module (
   $package_prefix      = $perl::package_prefix,
   $package_suffix      = $perl::package_suffix,
   $package_downcase    = $perl::package_downcase,
+  $module_check_cmd    = "perldoc -l ${name}",
 
   $url                 = '',
   $exec_path           = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin',
@@ -52,8 +53,8 @@ define perl::module (
   }
 
   $cpan_command_check = $ensure ? {
-    present => "perldoc -l ${name}",
-    absent  => "perldoc -l ${name} || true",
+    present => "${module_check_cmd}",
+    absent  => "${module_check_cmd} || true",
   }
 
   case $bool_use_package {


### PR DESCRIPTION
I ran into issue #8 when installing Bundle::LWP, so went ahead and added a parameter for an alternate module check command in my fork.   