### PR TITLE
Add 'G' flag to regsubst call in module.pp

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -32,8 +32,8 @@ define perl::module (
   include ::perl
 
   $pkg_name = $package_downcase ? {
-    true  => downcase(regsubst($name,'::','-')),
-    false => regsubst($name,'::','-'),
+    true  => downcase(regsubst($name,'::','-','G')),
+    false => regsubst($name,'::','-','G'),
   }
 
   $real_package_name = $package_name ? {


### PR DESCRIPTION
Translation of module name to package name only replaces first occurrence of `::` with `-`, so `Foo::Bar::Baz` results in `libfoo-bar::baz-perl` on Debian, or `perl-Foo-Bar::Baz` on RedHat. The `G` flag fixes it.