### PR TITLE
OSfamily v. Operating System

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,8 +18,8 @@ class perl::params {
   $cpan_mirror = 'http://www.perl.com/CPAN/'
 
   ### OS specific parameters
-  case $::operatingsystem {
-    /^(Debian|Ubuntu)$/ : {
+  case $::osfamily {
+    Debian : {
       $package          = 'perl'
       $doc_package      = 'perl-doc'
       $cpan_package     = 'perl'
@@ -28,7 +28,7 @@ class perl::params {
       $package_downcase = true
     }
 
-    /^(RedHat|CentOS|Amazon)$/ : {
+    RedHat : {
       $package          = 'perl'
       $doc_package      = ''
       $cpan_package     = 'perl-CPAN'


### PR DESCRIPTION
in the params.pp file, the main case for setting up the environment is restricted to delineated versions of Linux.  If you move the facter fact to "osfamily" you can catch a much more useful variety of Linux which are either Debian or RedHat based.  We use Scientific Linux (RedHat) and Bio-Linux (ubuntu) in our work, and would benefit from having these params set more generally than in the current method.   