### PR TITLE
Fix OS Family Matching for Future Parser

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class perl::params {
 
   ### OS specific parameters
   case $::osfamily {
-    Debian : {
+    'Debian' : {
       $package          = 'perl'
       $doc_package      = 'perl-doc'
       $cpan_package     = 'perl'
@@ -28,7 +28,7 @@ class perl::params {
       $package_downcase = true
     }
 
-    RedHat : {
+    'RedHat' : {
       $package          = 'perl'
       $doc_package      = ''
       $cpan_package     = 'perl-CPAN'


### PR DESCRIPTION
The future parser for Puppet 4 doesn't like these operating system names to be unquoted. This causes the match to fall through to the `default` case, which doesn't define `$package_downcase`, which causes the following error:

```
Error: Evaluation Error: No matching entry for selector parameter with value '' at /vagrant/modules/perl/manifests/module.pp:34:15 on node
 stg-dbmaster1
```

If I resolve the `$osfamily` fact, it resolves to `RedHat`, so it _should_ match, but it doesn't and falls through to the `default` case. As soon as I wrap the above operating system family names in params.pp with quotes, execution completes as expected.