### PR TITLE
fix Puppet Forge metadata quality warnings

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,5 +17,5 @@
   },
   "source": "https://github.com/example42/puppet-perl",
   "project_page": "http://www.example42.com",
-  "license": "Apache2"
+  "license": "Apache-2.0"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "dependencies": [
     {
       "name": "example42/puppi",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "types": [


### PR DESCRIPTION
This PR updates the `metadata.json` with the expressed intention of removing
the metadata quality warnings currently showing up on:
  https://forge.puppet.com/example42/perl/scores

Issue #29 