### PR TITLE
Support for --notest (e.g. #9)

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -15,6 +15,7 @@
 # perl::module { 'Net::SSLeay': }
 #
 define perl::module (
+  $no_test             = false,
   $use_package         = false,
   $package_name        = 'package_default',
   $package_prefix      = $::perl::package_prefix,
@@ -48,8 +49,13 @@ define perl::module (
     default       => $url,
   }
 
+  $cpan_opts = $no_test ? {
+    true  => "--notest",
+    false => "",
+  } 
+
   $cpan_command = $ensure ? {
-    'present' => "cpanm ${install_name}",
+    'present' => "cpanm ${cpan_opts} ${install_name}",
     'absent'  => "pm-uninstall -f ${name}",
   }
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -50,9 +50,9 @@ define perl::module (
   }
 
   $cpan_opts = $no_test ? {
-    true  => "--notest",
-    false => "",
-  } 
+    true  => '--notest',
+    false => '',
+  }
 
   $cpan_command = $ensure ? {
     'present' => "cpanm ${cpan_opts} ${install_name}",


### PR DESCRIPTION
Hi all,

I recently needed cpanm --notest support for puppet-perl, so here is a corresponding PR; it is quite minimal.

Kind regards,

Michael