### PR TITLE
Fixing error "Error while evaluating a Function Call, Cannot use empt…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,7 +104,7 @@ class perl (
   }
 
   ### Include custom class if $my_class is set
-  if $perl::my_class {
+  if $perl::my_class != '' {
     include $perl::my_class
   }
 


### PR DESCRIPTION
…y string as a class name"

When using Puppet Agent 5, there is a bug since the class name in variable $perl::my_class is default '' (empty string)


